### PR TITLE
Allow variable use before define

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ This module is based on the [Airbnb JavaScript Style Guide](https://github.com/a
   ```
 
 
-* `no-use-before-define`: usage of the functions before they are defined is allowed.
+* `no-use-before-define`: usage of the functions and variables before they are defined is allowed.
 
   ```json
   {
     "rules": {
-      "no-use-before-define": ["error", { "functions": false }]
+      "no-use-before-define": ["error", { "functions": false, "variables": false }]
     }
   }
   ```

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     }],
     'func-style': 0,
     'no-continue': 0,
-    'no-use-before-define': ['error', { 'functions': false }],
+    'no-use-before-define': ['error', { 'functions': false, 'variables': false }],
     'no-plusplus': 0,
     'no-process-env': 'error',
     radix: 0,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-tetrascience",
   "longName": "ESLint configuration using the TetraScience ECMA Script Style Guide.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "eslint-config-airbnb": "^15.0.1",
     "eslint-plugin-import": "^2.3.0",


### PR DESCRIPTION
Allows for private methods to be moved lower in file, similar to https://github.com/tetrascience/eslint-config-tetrascience/pull/6