### PR TITLE
DI-721 eslint & prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ $ yarn add tetrascience/eslint-config-tetrascience#^1.3.0 --dev
   $ yarn add prettier --dev
   ```
 
+* or you can install `prettier` globally
+
 * Refer to https://prettier.io/docs/en/editors.html for instructions
   on how to integrate `prettier` with editors.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ $ yarn add tetrascience/eslint-config-tetrascience#^1.3.0 --dev
 
 * or you can install `prettier` globally
 
+* create a `prettier.config.js` or `.prettierrc.js`
+  ```js
+  const prettierConfig = require('eslint-config-tetrascience/prettier.config');
+  module.exports = prettierConfig;
+  ```
+
 * Refer to https://prettier.io/docs/en/editors.html for instructions
   on how to integrate `prettier` with editors.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ __Table of Contents__
 
 ## Usage
 
-First, install the module as a `devDependency`:
+### install the module as a `devDependency`
 
 ```sh
 $ npm install tetrascience/eslint-config-tetrascience -D
 ```
 
-Then create an `.eslintrc` file to utilize the module:
+or
+
+```sh
+$ yarn add tetrascience/eslint-config-tetrascience#^1.3.0 --dev
+```
+
+### create an `.eslintrc` file to utilize the module
 
 ```json
 {
@@ -26,39 +32,28 @@ Then create an `.eslintrc` file to utilize the module:
 }
 ```
 
-* Refer to [ts-tool-microservice-boilerplate](https://github.com/tetrascience/ts-tool-microservice-boilerplate#setup) for instructions on how to enable that on webstorm
-  * Make sure that `eslint` is installed has a `devDependency`
+### setup `eslint`
+* install `eslint` as a `devDependency`
+
   ```sh
-  $ npm install eslint -D
+  $ yarn add eslint --dev
   ```
+
+* Refer to [ts-tool-microservice-boilerplate](https://github.com/tetrascience/ts-tool-microservice-boilerplate#setup) for instructions on how to enable that on webstorm
+
+### setup `prettier`
+
+* install `prettier` as a `devDependency`
+  ```sh
+  $ yarn add prettier --dev
+  ```
+
+* Refer to https://prettier.io/docs/en/editors.html for instructions
+  on how to integrate `prettier` with editors.
 
 ## Style Guide
 
 This module is based on the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript), and derives from [`eslint-config-airbnb`](https://www.npmjs.com/package/eslint-config-airbnb).  There are several overrides to the base module:
-
-* `comma-dangle`: functions with multi-line parameter lists forbid dangling commas.
-
-  ```json
-  {
-    "rules": {
-      "comma-dangle": [
-        "error",
-        { "function": "never" }
-      ]
-    }
-  }
-  ```
-
-* `func-style`: both function declarations and function expressions are allowed
-
-  ```json
-  {
-    "rules": {
-      "func-style": 0
-    }
-  }
-  ```
-
 
 * `no-use-before-define`: usage of the functions and variables before they are defined is allowed.
 
@@ -69,7 +64,6 @@ This module is based on the [Airbnb JavaScript Style Guide](https://github.com/a
     }
   }
   ```
-
 
 * `no-plusplus`: usage of the `++` incrementing operator is allowed.
 

--- a/index.js
+++ b/index.js
@@ -1,23 +1,19 @@
 module.exports = {
-  extends: ['airbnb'],
+  // this will turn off ESLint's formatting rules
+  extends: ['airbnb', 'prettier'],
   root: true,
   rules: {
-    'comma-dangle': ['error', {
-      arrays: 'always-multiline',
-      objects: 'always-multiline',
-      imports: 'always-multiline',
-      exports: 'always-multiline',
-      functions: 'never',
-    }],
-    'func-style': 0,
     'no-continue': 0,
-    'no-use-before-define': ['error', { 'functions': false, 'variables': false }],
+    'no-use-before-define': ['error', { functions: false, variables: false }],
     'no-plusplus': 0,
     'no-process-env': 'error',
     radix: 0,
     'valid-typeof': 0,
-    'no-underscore-dangle': ['error', {
-      allowAfterThis: true,
-    }],
+    'no-underscore-dangle': [
+      'error',
+      {
+        allowAfterThis: true,
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "longName": "ESLint configuration using the TetraScience ECMA Script Style Guide.",
   "version": "1.2.0",
   "dependencies": {
-    "eslint-config-airbnb": "^15.0.1",
-    "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-jsx-a11y": "^5.0.3",
-    "eslint-plugin-react": "^7.0.1"
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-config-prettier": "3.1.0",
+    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-react": "7.11.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0"
+    "eslint": "^5.3.0",
+    "prettier": "^1.14.3"
   },
   "keywords": [
     "errors"
@@ -22,7 +24,6 @@
     "url": "https://github.com/tetrascience/eslint-config-tetrascience"
   },
   "scripts": {
-    "lint": "eslint ./**/*.js",
-    "test": "NODE_ENV=test nyc --reporter=lcov  --reporter=text mocha --recursive ./test"
+    "lint": "eslint ./**/*.js"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  trailingComma: 'es5',
+  singleQuote: true,
+};


### PR DESCRIPTION
- disable prettier style checking in eslint
- use fixed version for dependent configs
- update readme

# Tips
- To setup prettier with your editor, please refer to https://prettier.io/docs/en/editors.html

# Questions
- To solve the conflict between eslint and prettier (https://prettier.io/docs/en/eslint.html). One is to disable eslint formatting rules, another is to "use eslint to run prettier". I choose the former one since it seems to be simple. What do you think?
- I lock the dependent config modules, not sure if it's a good choice. What do you think?